### PR TITLE
Update woocommerce.md and wordpress.md to fix broken links

### DIFF
--- a/integrations/woocommerce.md
+++ b/integrations/woocommerce.md
@@ -1,8 +1,8 @@
 # WooCommerce
 
 Official Repo
-
-{% embed data="{\"url\":\"https://github.com/BTCPrivate/btcp-widget/blob/master/plugin-woocommerce.php\",\"type\":\"link\",\"title\":\"BTCPrivate/btcp-widget\",\"description\":\"btcp-widget - JS widget for online shop payments\",\"icon\":{\"type\":\"icon\",\"url\":\"https://github.com/fluidicon.png\",\"aspectRatio\":0},\"thumbnail\":{\"type\":\"thumbnail\",\"url\":\"https://avatars0.githubusercontent.com/u/34813369?s=400&v=4\",\"width\":400,\"height\":400,\"aspectRatio\":1}}" %}
+{% embed data="{\"url\":\"https://github.com/BTCPrivate/btcp-widget/blob/master/plugins/btcp-pay-wordpress.php\",\"type\":\"link\",\"title\":\"BTCPrivate/btcp-widget\",\"description\":\"btcp-widget - JS widget for online shop payments\",\"icon\":{\"type\":\"icon\",\"url\":\"https://github.com/fluidicon.png\",\"aspectRatio\":0},\"thumbnail\":{\"type\":\"thumbnail\",\"url\":\"https://avatars0.githubusercontent.com/u/34813369?s=400&v=4\",\"width\":400,\"height\":400,\"aspectRatio\":1}}" %}
+ 
 
 ## Documentation 
 

--- a/integrations/wordpress.md
+++ b/integrations/wordpress.md
@@ -2,7 +2,7 @@
 
 Official Repo
 
-{% embed data="{\"url\":\"https://github.com/BTCPrivate/btcp-widget/blob/master/plugin-wordpress.php\",\"type\":\"link\",\"title\":\"BTCPrivate/btcp-widget\",\"description\":\"btcp-widget - JS widget for online shop payments\",\"icon\":{\"type\":\"icon\",\"url\":\"https://github.com/fluidicon.png\",\"aspectRatio\":0},\"thumbnail\":{\"type\":\"thumbnail\",\"url\":\"https://avatars0.githubusercontent.com/u/34813369?s=400&v=4\",\"width\":400,\"height\":400,\"aspectRatio\":1}}" %}
+{% embed data="{\"url\":\"https://github.com/BTCPrivate/btcp-widget/blob/master/plugins/btcp-pay-wordpress.php\",\"type\":\"link\",\"title\":\"BTCPrivate/btcp-widget\",\"description\":\"btcp-widget - JS widget for online shop payments\",\"icon\":{\"type\":\"icon\",\"url\":\"https://github.com/fluidicon.png\",\"aspectRatio\":0},\"thumbnail\":{\"type\":\"thumbnail\",\"url\":\"https://avatars0.githubusercontent.com/u/34813369?s=400&v=4\",\"width\":400,\"height\":400,\"aspectRatio\":1}}" %}
 
 ## Documentation
 


### PR DESCRIPTION
Updated old link directing to [link](https://github.com/BTCPrivate/btcp-widget/blob/master/plugin-woocommerce.php) (which is no longer existent) to this [link] (https://github.com/BTCPrivate/btcp-widget/blob/master/plugins/btcp-pay-woocommerce.php) and the same for wordpress.md with this [link](https://github.com/BTCPrivate/btcp-widget/blob/master/plugins/btcp-pay-wordpress.php)